### PR TITLE
Fix compiler error by removing reference to dump().

### DIFF
--- a/frugen.c
+++ b/frugen.c
@@ -615,7 +615,6 @@ int main(int argc, char *argv[])
 		if (!has_bdate && no_curr_date) {
 			debug(1, "Using 'unspecified' board mfg. date");
 			board.tv = (struct timeval){0};
-			dump(sizeof(board.tv), &board.tv);
 		}
 
 		bi = fru_board_info(&board);


### PR DESCRIPTION
This bug was introduced in 0f7c9b812268204219af6d17f7de3a3fd7887d45.

Signed-off-by: Oskar Senft <osk@google.com>