### PR TITLE
Feature/disable autoencoding force ascii

### DIFF
--- a/fru.c
+++ b/fru.c
@@ -99,7 +99,11 @@ uint8_t fru_get_typelen(int len,             /**< [in] Length of the data or LEN
 
 	// Go through the data and expand charset as needed
 	for (i = 0; i < len; i++) {
-		if (data[i] < ' ') {
+		if (data[i] < ' '
+			&& data[i] != '\t'
+			&& data[i] != '\r'
+			&& data[i] != '\n')
+		{
 			// They lied! The data is binary!
 			// That's the widest range type.
 			// There is no use in checking any further.
@@ -108,7 +112,9 @@ uint8_t fru_get_typelen(int len,             /**< [in] Length of the data or LEN
 			break;
 		}
 
-		if (typelen < FRU_MAKETYPE(TEXT) && data[i] > '_') { // Do not reduce the range
+		if (typelen < FRU_MAKETYPE(TEXT)
+			&& (data[i] > '_' || data[i] < ' '))
+		{ // Do not reduce the range
 			// The data doesn't fit into 6-bit ASCII, expand to simple text.
 			DEBUG("[%c] Data is simple text!\n", data[i]);
 			typelen = FRU_TYPELEN(TEXT, len);

--- a/fru.h
+++ b/fru.h
@@ -8,6 +8,7 @@
 #ifndef __FRULIB_FRU_H__
 #define __FRULIB_FRU_H__
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -299,6 +300,8 @@ typedef struct {
 } fru_exploded_product_t;
 
 #define fru_loadfield(eafield, value) strncpy(eafield, value, FRU_FIELDMAXLEN)
+
+void fru_set_autodetect(bool enable);
 
 fru_chassis_area_t * fru_chassis_info(const fru_exploded_chassis_t *chassis);
 fru_board_area_t * fru_board_info(const fru_exploded_board_t *board);

--- a/frugen.c
+++ b/frugen.c
@@ -492,8 +492,10 @@ int main(int argc, char *argv[])
 					   "\n"
 					   "Options:\n\n");
 				for (i = 0; i < ARRAY_SZ(options); i++) {
-					printf("\t--%s%s\n" /* "\t-%c%s\n" */, options[i].name,
-						                      options[i].has_arg ? " <argument>" : "");
+					printf("\t-%c, --%s%s\n" /* "\t-%c%s\n" */,
+					       options[i].val,
+					       options[i].name,
+					       options[i].has_arg ? " <argument>" : "");
 					printf("\t\t%s.\n\n", option_help[options[i].val]);
 				}
 				printf("Example:\n"

--- a/frugen.c
+++ b/frugen.c
@@ -378,6 +378,11 @@ int main(int argc, char *argv[])
 		/* Mark the following '*-custom' data as binary */
 		{ .name = "binary",        .val = 'b', .has_arg = false },
 
+		/* Disable autodetection, force ASCII encoding on standard fields,
+		 * Detection of binary (out of ASCII range) stays in place.
+		 */
+		{ .name = "ascii",         .val = 'I', .has_arg = false },
+
 		/* Set input file format to JSON */
 		{ .name = "json",          .val = 'j', .has_arg = false },
 
@@ -420,6 +425,8 @@ int main(int argc, char *argv[])
 			    "Example: frugen --binary --board-custom 0012DEADBEAF\n"
 			    "\n\t\t"
 			    "There must be an even number of characters in a 'binary' argument",
+		['I'] = "Disable auto-encoding on all fields, force ASCII.\n\t\t"
+			    "Out of ASCII range data will still result in binary encoding.",
 		['j'] = "Set input text file format to JSON (default). Specify before '--from'",
 		['z'] = "Load FRU information from a text file",
 		/* Chassis info area related options */
@@ -478,6 +485,9 @@ int main(int argc, char *argv[])
 			case 'b': // binary
 				debug(2, "Next custom field will be considered binary");
 				cust_binary = true;
+				break;
+			case 'I': // ASCII
+				fru_set_autodetect(false);
 				break;
 			case 'v': // verbose
 				debug_level++;


### PR DESCRIPTION
This commit partially addresses #11. It doesn't allow for forcing any specific encoding per field, but it is now possible to globally force ASCII encoding.

Use `frugen --ascii` to globally force 8-bit ASCII encoding. If the data is out of ASCII range, it will still be encoded as binary regardless of this new option.