### PR TITLE
Add --tags to git describe call so we grab a tagged version number if it exists.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ execute_process(COMMAND
 	--always
 	--long
 	--dirty
+	--tags
 	WORKING_DIRECTORY
 	"${CMAKE_CURRENT_SOURCE_DIR}"
 	RESULT_VARIABLE


### PR DESCRIPTION
Currently, the cmake script generates incorrect values for binary versions when building frugen. As an example, if you check out the v1.3 tag, the scripts will built it with the version string for v.1.2.4, whereas they should use 1.3.0. Adding --tags will check for tag matches in the git describe call.

Incorrect:
FRU Generator v1.2.4.g3bad90e (c) 2016-2021, Alexander Amelkin <alexander@amelkin.msk.ru>

Correct:
FRU Generator v1.3.0.g3bad90e (c) 2016-2021, Alexander Amelkin <alexander@amelkin.msk.ru>