### PR TITLE
Add cmake project definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
+project(frugen C)
 if(COMMAND cmake_policy)
 	cmake_policy(SET CMP0003 NEW)
 endif(COMMAND cmake_policy)


### PR DESCRIPTION
Currently, CMake complains about project not being set:

> CMake Warning (dev) in CMakeLists.txt:
  No project() command is present.  The top-level CMakeLists.txt file must
  contain a literal, direct call to the project() command.  Add a line of
  code such as
    project(ProjectName)
  near the top of the file, but after cmake_minimum_required().

This PR removes this warning by adding a project definition.