### PR TITLE
Control DEBUG definition from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,12 @@ endif()
 
 string(REPLACE "-" "." gitver "${gitver}")
 
+option(DEBUG_OUTPUT "show extra debug output" OFF)
+
+if (DEBUG_OUTPUT)
+  add_definitions(-DDEBUG)
+endif()
+
 add_definitions(-DVERSION="${gitver}")
 
 add_executable(frugen frugen.c)


### PR DESCRIPTION
Add `DEBUG` option to CMake so that debug output could be turned on without touching the sources.