### PR TITLE
Add field types

### DIFF
--- a/example.json
+++ b/example.json
@@ -5,10 +5,19 @@
 	"chassis" : {
 		"type": 10,
 		"pn" : "CHAS-C00L-12",
-		"serial": "45678",
+		/* Fields may be given explicit types by setting to object with keys `type` and `data`*/
+		/* Supported types are: "bcdplus", "6bitascii" and "text" */
+		"serial": {
+		    "type": "bcdplus",
+		    "data": "45678"
+		},
 		"custom" : [
 			{ "data" : "Auto-typed text custom field" },
-			{ "type" : "binary", "data": "B14A87" }
+			{ "type" : "binary", "data": "B14A87" },
+			/* For explicit text types range is not checked, so be careful */
+			{ "type" : "bcdplus", "data": "1234" },
+			{ "type" : "6bitascii", "data": "1234" },
+			{ "type" : "text", "data": "1234" }
 		]
 	},
 	"board" : {

--- a/fru.h
+++ b/fru.h
@@ -260,6 +260,9 @@ typedef fru_mr_rec_t fru_mr_area_t; /// Intended for use as a pointer only
 #define FRU_ISTYPE(t, type)   (FRU_TYPE(t) == __TYPE_##type)
 
 #define LEN_AUTO              0
+#define LEN_BCDPLUS           -1
+#define LEN_6BITASCII         -2
+#define LEN_TEXT              -3
 
 #define FRU_6BIT_LENGTH(len)    (((len) * 3 + 3) / 4)
 #define FRU_6BIT_FULLLENGTH(l6) (((l6) * 4) / 3)
@@ -271,32 +274,43 @@ typedef fru_mr_rec_t fru_mr_area_t; /// Intended for use as a pointer only
 #define FRU_BLOCKS(bytes)  (((bytes) + FRU_BLOCK_SZ - 1) / FRU_BLOCK_SZ)
 
 typedef struct {
+	enum {
+		FIELD_TYPE_AUTO,
+		FIELD_TYPE_BINARY,
+		FIELD_TYPE_BCDPLUS,
+		FIELD_TYPE_SIXBITASCII,
+		FIELD_TYPE_TEXT
+	} type;
+	unsigned char val[FRU_FIELDMAXARRAY];
+} typed_field_t;
+
+typedef struct {
 	uint8_t type;
-	unsigned char pn[FRU_FIELDMAXARRAY];
-	unsigned char serial[FRU_FIELDMAXARRAY];
+	typed_field_t pn;
+	typed_field_t serial;
 	fru_reclist_t *cust;
 } fru_exploded_chassis_t;
 
 typedef struct {
 	uint8_t lang;
 	struct timeval tv;
-	unsigned char mfg[FRU_FIELDMAXARRAY];
-	unsigned char pname[FRU_FIELDMAXARRAY];
-	unsigned char serial[FRU_FIELDMAXARRAY];
-	unsigned char pn[FRU_FIELDMAXARRAY];
-	unsigned char file[FRU_FIELDMAXARRAY];
+	typed_field_t mfg;
+	typed_field_t pname;
+	typed_field_t serial;
+	typed_field_t pn;
+	typed_field_t file;
 	fru_reclist_t *cust;
 } fru_exploded_board_t;
 
 typedef struct {
 	uint8_t lang;
-	unsigned char mfg[FRU_FIELDMAXARRAY];
-	unsigned char pname[FRU_FIELDMAXARRAY];
-	unsigned char pn[FRU_FIELDMAXARRAY];
-	unsigned char ver[FRU_FIELDMAXARRAY];
-	unsigned char serial[FRU_FIELDMAXARRAY];
-	unsigned char atag[FRU_FIELDMAXARRAY];
-	unsigned char file[FRU_FIELDMAXARRAY];
+	typed_field_t mfg;
+	typed_field_t pname;
+	typed_field_t pn;
+	typed_field_t ver;
+	typed_field_t serial;
+	typed_field_t atag;
+	typed_field_t file;
 	fru_reclist_t *cust;
 } fru_exploded_product_t;
 


### PR DESCRIPTION
This PR adds support for setting types for fields from JSON input.
In order to specify field type, one needs to change JSON field form
```json
"field": "value"
```
to
```json
"field": {
    "type": "text",
    "val": "value"
}
```
Supported types are `bcdplus`, `6bitascii` and `text`.

This feature is not yet implemented for custom fields, but doing so should be trivial. Will do this after a bit of testing.

Conversion of the `example.json` with this and the original versions generate exactly the same files.

Closes #11